### PR TITLE
Performance Patch and some logic changes

### DIFF
--- a/addons/sourcemod/scripting/vip/Database.sp
+++ b/addons/sourcemod/scripting/vip/Database.sp
@@ -142,8 +142,7 @@ void RemoveExpAndOutPlayers()
 		DBG_SQL_Query(szQuery)
 		g_hDatabase.Query(SQL_Callback_SelectExpiredAndOutdated, szQuery, REASON_EXPIRED);
 	}
-
-	if (g_CVAR_iOutdatedExpired > 0)
+	else
 	{
 		char szQuery[256];
 		FormatEx(SZF(szQuery), "SELECT `account_id`, `name`, `group` FROM `vip_users` WHERE `lastvisit` > 0 AND `lastvisit` < %d%s;", (GetTime() - g_CVAR_iOutdatedExpired*86400), g_szSID);
@@ -270,15 +269,13 @@ void DB_RemoveClientFromID(int iAdmin = 0,
 	g_hDatabase.Query(SQL_Callback_SelectRemoveClient, szQuery, hDataPack);
 }
 
-public void SQL_Callback_SelectRemoveClient(Database hOwner, DBResultSet hResult, const char[] szError, any hPack)
+public void SQL_Callback_SelectRemoveClient(Database hOwner, DBResultSet hResult, const char[] szError, DataPack hPack)
 {
 	DBG_SQL_Response("SQL_Callback_SelectRemoveClient")
 
-	DataPack hDataPack = view_as<DataPack>(hPack);
-	
 	if (szError[0])
 	{
-		delete hDataPack;
+		delete hPack;
 		LogError("SQL_Callback_SelectRemoveClient: %s", szError);
 		return;
 	}
@@ -286,20 +283,20 @@ public void SQL_Callback_SelectRemoveClient(Database hOwner, DBResultSet hResult
 	if (hResult.FetchRow())
 	{
 		DBG_SQL_Response("hResult.FetchRow()")
-		hDataPack.Reset();
-		int iClientID = hDataPack.ReadCell();
-		hDataPack.ReadCell();
-		hDataPack.ReadCell();
+		hPack.Reset();
+		int iClientID = hPack.ReadCell();
+		hPack.ReadCell();
+		hPack.ReadCell();
 		char szName[MAX_NAME_LENGTH*2+1];
-		hDataPack.ReadString(SZF(szName));
+		hPack.ReadString(SZF(szName));
 		hResult.FetchString(0, SZF(szName));
 		DBG_SQL_Response("hResult.FetchString(0) = '%s", szName)
-		hDataPack.WriteString(szName);
+		hPack.WriteString(szName);
 		hResult.FetchString(1, SZF(szName));
 		DBG_SQL_Response("hResult.FetchString(1) = '%s", szName)
-		hDataPack.WriteString(szName);
+		hPack.WriteString(szName);
 
-		DB_RemoveClient(hDataPack, iClientID);
+		DB_RemoveClient(hPack, iClientID);
 	}
 }
 
@@ -312,15 +309,13 @@ void DB_RemoveClient(DataPack hDataPack, int iClientID)
 	g_hDatabase.Query(SQL_Callback_RemoveClient, szQuery, hDataPack);
 }
 
-public void SQL_Callback_RemoveClient(Database hOwner, DBResultSet hResult, const char[] szError, any hPack)
+public void SQL_Callback_RemoveClient(Database hOwner, DBResultSet hResult, const char[] szError, DataPack hPack)
 {
 	DBG_SQL_Response("SQL_Callback_SelectRemoveClient")
 
-	DataPack hDataPack = view_as<DataPack>(hPack);
-
 	if (szError[0])
 	{
-		delete hDataPack;
+		delete hPack;
 		LogError("SQL_Callback_RemoveClient: %s", szError);
 		return;
 	}
@@ -329,17 +324,15 @@ public void SQL_Callback_RemoveClient(Database hOwner, DBResultSet hResult, cons
 
 	if (hResult.AffectedRows)
 	{
-		hDataPack.Reset();
+		hPack.Reset();
 		
-		int iClientID = hDataPack.ReadCell();
-		int iAdmin = GET_CID(hDataPack.ReadCell());
-		bool bNotify = view_as<bool>(hDataPack.ReadCell());
+		int iClientID = hPack.ReadCell();
+		int iAdmin = GET_CID(hPack.ReadCell());
+		bool bNotify = view_as<bool>(hPack.ReadCell());
 		char szAdmin[128], szName[MNL], szGroup[64];
-		hDataPack.ReadString(SZF(szAdmin));
-		hDataPack.ReadString(SZF(szName));
-		hDataPack.ReadString(SZF(szGroup));
-		
-		delete hDataPack;
+		hPack.ReadString(SZF(szAdmin));
+		hPack.ReadString(SZF(szName));
+		hPack.ReadString(SZF(szGroup));
 
 		if(iAdmin == -1)
 		{
@@ -356,9 +349,11 @@ public void SQL_Callback_RemoveClient(Database hOwner, DBResultSet hResult, cons
 			ReplyToCommand(iAdmin, "%t", "ADMIN_VIP_PLAYER_DELETED", szName, iClientID);
 		}
 	}
+
+	delete hPack;
 }
 
-public void SQL_Callback_SelectExpiredAndOutdated(Database hOwner, DBResultSet hResult, const char[] szError, any iReason)
+public void SQL_Callback_SelectExpiredAndOutdated(Database hOwner, DBResultSet hResult, const char[] szError, int iReason)
 {
 	DBG_SQL_Response("SQL_Callback_SelectExpiredAndOutdated")
 

--- a/addons/sourcemod/scripting/vip/Database.sp
+++ b/addons/sourcemod/scripting/vip/Database.sp
@@ -142,7 +142,8 @@ void RemoveExpAndOutPlayers()
 		DBG_SQL_Query(szQuery)
 		g_hDatabase.Query(SQL_Callback_SelectExpiredAndOutdated, szQuery, REASON_EXPIRED);
 	}
-	else
+
+	if (g_CVAR_iOutdatedExpired > 0)
 	{
 		char szQuery[256];
 		FormatEx(SZF(szQuery), "SELECT `account_id`, `name`, `group` FROM `vip_users` WHERE `lastvisit` > 0 AND `lastvisit` < %d%s;", (GetTime() - g_CVAR_iOutdatedExpired*86400), g_szSID);

--- a/addons/sourcemod/scripting/vip/Downloads.sp
+++ b/addons/sourcemod/scripting/vip/Downloads.sp
@@ -65,7 +65,7 @@ bool Dir_AddToDownloadsTable(const char[] szPath)
 			char szDirEntry[PLATFORM_MAX_PATH];
 			while (hDir.GetNext(SZF(szDirEntry)))
 			{
-				if ((UTIL_StrCmpEx(szDirEntry, ".") || UTIL_StrCmpEx(szDirEntry, "..")) == false)
+				if ((UTIL_StrCmpEx(szDirEntry, ".") || UTIL_StrCmpEx(szDirEntry, "..") || UTIL_StrCmpEx(szDirEntry[strlen(szDirEntry)-4], ".bz2")) == false)
 				{
 					Format(SZF(szDirEntry), "%s/%s", szPath, szDirEntry);
 

--- a/addons/sourcemod/scripting/vip/UTIL.sp
+++ b/addons/sourcemod/scripting/vip/UTIL.sp
@@ -45,12 +45,16 @@ stock int UTIL_ReplaceChars(char[] szBuffer, int InChar, int OutChar)
 
 bool UTIL_StrCmpEx(const char[] szString1, const char[] szString2)
 {
-	int iLen1 = strlen(szString1), 
-	iLen2 = strlen(szString2);
+	int iLen = strlen(szString1);
+	if (iLen != strlen(szString2))
+	{
+		// i don't see any reason, why we should compare strings,
+		// if length is different because this fact means: they
+		// different too.
+		return false;
+	}
 
-	int MaxLen = (iLen1 > iLen2) ? iLen1:iLen2, i;
-
-	for (i = 0; i < MaxLen; i++)
+	for (int i = 0; i < iLen; i++)
 	{
 		if (szString1[i] != szString2[i])
 		{
@@ -165,7 +169,7 @@ void UTIL_LoadVipCmd(ConVar &hCvar, ConCmd Call_CMD)
 	}
 }
 
-int UTIL_GetConVarAdminFlag(ConVar &hCvar)
+int UTIL_GetConVarAdminFlag(ConVar hCvar)
 {
 	char szBuffer[32];
 	hCvar.GetString(SZF(szBuffer));

--- a/addons/sourcemod/scripting/vip/VipMenu.sp
+++ b/addons/sourcemod/scripting/vip/VipMenu.sp
@@ -141,8 +141,8 @@ public int Handler_VIPMenu(Menu hMenu, MenuAction action, int iClient, int iOpti
 			int iExp;
 			if (g_hFeatures[iClient].GetValue(KEY_EXPIRES, iExp) && iExp > 0)
 			{
-				int iTime;
-				if ((iTime = GetTime()) < iExp)
+				int iTime = GetTime();
+				if (iTime < iExp)
 				{
 					char szExpires[64];
 					UTIL_GetTimeFromStamp(SZF(szExpires), iExp - iTime, iClient);


### PR DESCRIPTION
- In SQL callbacks we can pass any type without `view_as`
- Added more readability in `VipMenu.sp`
- Small performance patch in `UTIL_StrCmpEx()`
- If filename ends on `.bz2`, we don't should add him in download list. This required for FastDL solutions like [this](https://c-s.net.ua/forum/topic67228.html).