### PR TITLE
Ensure cfg/vip folder exists

### DIFF
--- a/addons/sourcemod/scripting/vip/Cvars.sp
+++ b/addons/sourcemod/scripting/vip/Cvars.sp
@@ -61,6 +61,9 @@ void Cvars_Setup()
 	hCvar.AddChangeHook(OnLogsEnableChange);
 	g_CVAR_bLogsEnable = hCvar.BoolValue;
 
+	if (!DirExists("cfg/vip"))
+		CreateDirectory("cfg/vip", 511);
+	
 	AutoExecConfig(true, "VIP_Core", "vip");
 }
 


### PR DESCRIPTION
В архиве на сайте этой папки нет, следовательно, стоит предположить, что плагин должен делать это сам.