### PR TITLE
Добавлен новый вызов: VIP_OnClientDisconnect

### DIFF
--- a/addons/sourcemod/scripting/include/vip_core.inc
+++ b/addons/sourcemod/scripting/include/vip_core.inc
@@ -185,6 +185,16 @@ forward void VIP_OnClientLoaded(int iClient, bool bIsVIP);
 forward void VIP_OnVIPClientLoaded(int iClient);
 
 /**
+ *	Вызывается когда игрок на стадии отключения.
+ *
+ * @param iClient			Индекс игрока.
+ * @param bIsVIP			Имеет ли игрок VIP-статус.
+ *
+ * @noreturn
+*/
+forward void VIP_OnClientDisconnect(int iClient, bool bIsVIP);
+
+/**
  *	Вызывается когда игрок получает VIP-статус.
  *
  * @param iClient			Индекс игрока.

--- a/addons/sourcemod/scripting/vip/API.sp
+++ b/addons/sourcemod/scripting/vip/API.sp
@@ -10,6 +10,7 @@ static Handle g_hGlobalForward_OnShowClientInfo;
 static Handle g_hGlobalForward_OnFeatureToggle;
 static Handle g_hGlobalForward_OnFeatureRegistered;
 static Handle g_hGlobalForward_OnFeatureUnregistered;
+static Handle g_hGlobalForward_OnClientDisconnect;
 
 void API_SetupForwards()
 {
@@ -25,6 +26,7 @@ void API_SetupForwards()
 	g_hGlobalForward_OnFeatureToggle				= CreateGlobalForward("VIP_OnFeatureToggle", ET_Ignore, Param_Cell, Param_String, Param_Cell, Param_CellByRef);
 	g_hGlobalForward_OnFeatureRegistered			= CreateGlobalForward("VIP_OnFeatureRegistered", ET_Ignore, Param_String);
 	g_hGlobalForward_OnFeatureUnregistered			= CreateGlobalForward("VIP_OnFeatureUnregistered", ET_Ignore, Param_String);
+	g_hGlobalForward_OnClientDisconnect             = CreateGlobalForward("VIP_OnClientDisconnect", ET_Ignore, Param_Cell, Param_Cell);
 }
 
 // Global Forwards
@@ -61,6 +63,15 @@ void CreateForward_OnVIPClientLoaded(int iClient)
 	DBG_API("CreateForward_OnVIPClientLoaded(%N (%d))", iClient, iClient)
 	Call_StartForward(g_hGlobalForward_OnVIPClientLoaded);
 	Call_PushCell(iClient);
+	Call_Finish();
+}
+
+void CreateForward_OnClientDisconnect(int iClient)
+{
+	DBG_API("CreateForward_OnClientDisconnect(%N (%d), %b)", iClient, iClient, g_iClientInfo[iClient] & IS_VIP)
+	Call_StartForward(g_hGlobalForward_OnClientDisconnect);
+	Call_PushCell(iClient);
+	Call_PushCell(g_iClientInfo[iClient] & IS_VIP);
 	Call_Finish();
 }
 

--- a/addons/sourcemod/scripting/vip/Clients.sp
+++ b/addons/sourcemod/scripting/vip/Clients.sp
@@ -25,7 +25,10 @@ public void OnClientDisconnect(int iClient)
 		SaveClient(iClient);
 	}*/
 
-	CreateForward_OnClientDisconnect(iClient);
+	if(!IsFakeClient(iClient))
+	{
+		CreateForward_OnClientDisconnect(iClient);
+	}
 	
 	ResetClient(iClient);
 	UTIL_CloseHandleEx(g_hClientData[iClient]);

--- a/addons/sourcemod/scripting/vip/Clients.sp
+++ b/addons/sourcemod/scripting/vip/Clients.sp
@@ -24,6 +24,8 @@ public void OnClientDisconnect(int iClient)
 	{
 		SaveClient(iClient);
 	}*/
+
+	CreateForward_OnClientDisconnect(iClient);
 	
 	ResetClient(iClient);
 	UTIL_CloseHandleEx(g_hClientData[iClient]);


### PR DESCRIPTION
Если ядро `VIP`, на стадии отключения, отработало раньше, то проверка на `VIP` статус бессмысленна, что может вызывать проблемы.