### PR TITLE
feat(VIP-Core): make it possible to add a local vip before database checks and before OnClientPutInServer

### DIFF
--- a/addons/sourcemod/scripting/vip/API.sp
+++ b/addons/sourcemod/scripting/vip/API.sp
@@ -1277,7 +1277,7 @@ bool CheckValidClient(const int &iClient, bool bCheckVIP = true)
 		ThrowNativeError(SP_ERROR_NATIVE, "Invalid client index/Некорректный индекс игрока (%i)", iClient);
 		return false;
 	}
-	if (IsClientInGame(iClient) == false)
+	if (bCheckVIP && IsClientInGame(iClient) == false)
 	{
 		ThrowNativeError(SP_ERROR_NATIVE, "Client %i is not connected/Игрок %i не подключен", iClient, iClient);
 		return false;

--- a/addons/sourcemod/scripting/vip/Clients.sp
+++ b/addons/sourcemod/scripting/vip/Clients.sp
@@ -7,6 +7,13 @@ void ResetClient(int iClient)
 	UTIL_CloseHandleEx(g_hFeatureStatus[iClient]);
 }
 
+public bool OnClientConnect(int client, char[] rejectmsg, int maxlen)
+{
+	ResetClient(client);
+
+	return true;
+}
+
 public void OnClientPutInServer(int iClient)
 {
 	//	g_iClientInfo[iClient] = 0;
@@ -42,10 +49,6 @@ void Clients_CheckVipAccess(int iClient, bool bNotify = false, bool bForward = f
 		return;
 	}
 
-	g_iClientInfo[iClient] &= ~IS_LOADED;
-	
-	ResetClient(iClient);
-	
 	if (IsFakeClient(iClient) == false && (GLOBAL_INFO & IS_STARTED) && g_hDatabase)
 	{
 		Clients_LoadClient(iClient, bNotify);


### PR DESCRIPTION
We can use this in free vip giveaway module like this:
```
public void OnClientPutInServer(int client)
{
	if (GetConVarInt(g_Cvar_MinPlayers) != 0)
		return;

	char vipGroup[16];
	GetConVarString(g_Cvar_VIPGroup, vipGroup, sizeof(vipGroup));

	if (client && IsClientInGame(client) && !IsFakeClient(client) && !VIP_IsClientVIP(client))
	{
		VIP_GiveClientVIP(_, client, 0, vipGroup, false);
	}
}
```

Example module: https://gitlab.com/counterstrikesource/sm-plugins/vip-freevipgiveaway