### PR TITLE
fix: invalid steam account id

### DIFF
--- a/addons/sourcemod/scripting/VIP_Core.sp
+++ b/addons/sourcemod/scripting/VIP_Core.sp
@@ -7,7 +7,7 @@
 #include <clientprefs>
 
 #if !defined VIP_VERSION
-#define VIP_VERSION		"3.0.4 R"
+#define VIP_VERSION		"3.0.5 R"
 #endif
 
 

--- a/addons/sourcemod/scripting/vip/UTIL.sp
+++ b/addons/sourcemod/scripting/vip/UTIL.sp
@@ -310,6 +310,12 @@ void UTIL_ADD_VIP_PLAYER(int iAdmin = 0,
 		FormatEx(SZF(szTargetInfo), "unknown (%s, unknown)", szQuery);
 	}
 
+	if (iAccountID == 0)
+	{
+		UTIL_Reply(iAdmin, "%t", "ADMIN_VIP_ADD_FAILED");
+		return;
+	}
+
 	DataPack hDataPack = new DataPack();
 
 	// Admin


### PR DESCRIPTION
Prevent inserting bad value into the database.
- Can be done by adding a player in STEAM_ID_PENDING